### PR TITLE
updated issue where closing a dialog would throw an exception on IE b…

### DIFF
--- a/ui-bootstrap-tpls.js
+++ b/ui-bootstrap-tpls.js
@@ -2649,7 +2649,7 @@ angular.module('ui.bootstrap.modal', [])
         //move focus to specified element if available, or else to body
         if (elementToReceiveFocus && elementToReceiveFocus.focus) {
           elementToReceiveFocus.focus();
-        } else {
+        } else if (body.focus) {
           body.focus();
         }
       }


### PR DESCRIPTION
…ecause of a missing .focus() method
